### PR TITLE
Add with demoted errors when fontifying code

### DIFF
--- a/shr-tag-pre-highlight.el
+++ b/shr-tag-pre-highlight.el
@@ -217,9 +217,10 @@ Adapted from `org-src--get-lang-mode'."
                     (shr-tag-pre-highlight--get-lang-mode lang))))
     (shr-ensure-newline)
     (insert
-     (if (fboundp mode)
-         (shr-tag-pre-highlight-fontify code mode)
-       code))
+     (or (and (fboundp mode)
+              (with-demoted-errors "Error while fontifying: %S"
+                (shr-tag-pre-highlight-fontify code mode)))
+         code))
     (shr-ensure-newline)))
 
 (provide 'shr-tag-pre-highlight)


### PR DESCRIPTION
This adds a safe fallback when a fontify function fails.