### PR TITLE
Set `untrusted-content` when fontifying code

### DIFF
--- a/shr-tag-pre-highlight.el
+++ b/shr-tag-pre-highlight.el
@@ -193,6 +193,8 @@ Adapted from `org-src--get-lang-mode'."
 (defun shr-tag-pre-highlight-fontify (code mode)
   "Fontify CODE with Major MODE."
   (with-temp-buffer
+    (when (boundp 'untrusted-content)
+      (set 'untrusted-content t))
     (insert code)
     (delay-mode-hooks (funcall mode))
     (if (fboundp 'font-lock-ensure)


### PR DESCRIPTION
This variable was introduced in Emacs 29.3 to mark a buffer as "untrusted". This is used, e.g., when fontifying code attachments to Email.